### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -88,7 +88,6 @@
                     "properties": {
                         "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]",
                         "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]",
-                        "AZUREJOBS_EXTENSION_VERSION": "beta",
                         "FUNCTIONS_EXTENSION_VERSION": "~0.5",
                         "EmotionAPIKey": "[parameters('emotionAPIKey')]"
                     }


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.